### PR TITLE
学生ユーザーの年齢をundefinedの状態でもnullとして格納する

### DIFF
--- a/src/user/dto/update-user.input.ts
+++ b/src/user/dto/update-user.input.ts
@@ -14,7 +14,7 @@ export class UpdateUserInput {
   imageUrl?: string;
 
   @IsOptional()
-  age?: string | number;
+  age?: string | number | null;
 
   @IsString()
   @IsOptional()

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -106,16 +106,14 @@ export class UserController {
       };
     }
 
-    if (input.age) {
-      input = {
-        ...input,
-        age: parseInt(input.age as string),
-      };
-    }
+    input = {
+      ...input,
+      age: input.age ? parseInt(input.age as string) : null,
+    };
 
     return await this.userService.updateByFirebaseUID(
       authUser.uid,
-      input as UpdateUserInput & { age: number },
+      input as UpdateUserInput & { age: number | null },
     );
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -47,7 +47,7 @@ export class UserService {
 
   updateByFirebaseUID(
     firebaseUID: string,
-    input: UpdateUserInput & { age: number },
+    input: UpdateUserInput & { age: number | null },
   ): PrismaPromise<User> {
     return this.prismaService.user.update({
       where: { firebaseUID },


### PR DESCRIPTION
## 概要
学生ユーザーをアップデートする際に、年齢カラムをnumberかnullで保存させるようにしました。