### PR TITLE
 chat-event/ 以外のチャット関連のテスト

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:unit": "dotenv -e .env.test jest ${npm_config_path}",
     "test:e2e": "jest --config ./test/jest-e2e.json -i"
   },
   "dependencies": {

--- a/src/chat-event/chat-event.module.ts
+++ b/src/chat-event/chat-event.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { ChatEventGateway } from './chat-event.gateway';
-import { SendMessage } from './use-case/send-message';
+import { ChatEventGateway } from './gateways/chat-event.gateway';
+import { SendMessageService } from './use-case/send-message.service';
 import { ChatRoomMessageModule } from 'src/chat-room-message/chat-room-message.module';
 import { UserModule } from 'src/user/user.module';
 import { ChatRoomParticipantModule } from 'src/chat-room-participant/chat-room-participant.module';
@@ -13,6 +13,7 @@ import { EmployeeModule } from 'src/employee/employee.module';
     ChatRoomParticipantModule,
     EmployeeModule,
   ],
-  providers: [ChatEventGateway, SendMessage],
+  providers: [ChatEventGateway, SendMessageService],
+  exports: [SendMessageService],
 })
 export class ChatEventModule {}

--- a/src/chat-event/gateways/chat-event.gateway.ts
+++ b/src/chat-event/gateways/chat-event.gateway.ts
@@ -5,18 +5,19 @@ import {
   WebSocketServer,
 } from '@nestjs/websockets';
 import { Server } from 'socket.io';
-import { ChatMessageInput } from './dto/chat-message.input';
-import { SendMessage } from './use-case/send-message';
+import { ChatMessageInput } from '../dto/chat-message.input';
+import { SendMessageService } from '../use-case/send-message.service';
 import { UseGuards } from '@nestjs/common';
-import { ChatSenderGuard } from './guards/chat-sender.guard';
+import { ChatSenderGuard } from '../guards/chat-sender.guard';
 import { ChatSender } from 'src/chat-event/decorators/chat-sender.decorator';
-import { ChatSenderInput } from './dto/chat-sender.input';
+import { ChatSenderInput } from '../dto/chat-sender.input';
+import { ChatRoomMessageEntity } from 'src/chat-room-message/entities/chat-room-message.entity';
 
 @WebSocketGateway({
   cors: { origin: [process.env.UNITE_API_URL, process.env.UNITE_FRONT_URL] },
 })
 export class ChatEventGateway {
-  constructor(private readonly sendMessage: SendMessage) {}
+  constructor(private readonly sendMessageService: SendMessageService) {}
 
   @WebSocketServer()
   server: Server;
@@ -26,7 +27,7 @@ export class ChatEventGateway {
   async handleMessage(
     @ChatSender() sender: ChatSenderInput,
     @MessageBody() input: ChatMessageInput,
-  ): Promise<void> {
-    await this.sendMessage.handle(this.server, sender, input);
+  ): Promise<ChatRoomMessageEntity> {
+    return await this.sendMessageService.handle(this.server, sender, input);
   }
 }

--- a/src/chat-event/use-case/send-message-service.spec.ts
+++ b/src/chat-event/use-case/send-message-service.spec.ts
@@ -1,0 +1,87 @@
+import { Server } from 'socket.io';
+import { SendMessageService } from './send-message.service';
+import { Test } from '@nestjs/testing';
+import { ChatSenderInput } from '../dto/chat-sender.input';
+import { ChatMessageInput } from '../dto/chat-message.input';
+import { ChatRoomMessageService } from '../../chat-room-message/chat-room-message.service';
+
+describe('SendMessageService Service', () => {
+  let server: Server;
+  let sendMessageSerSendMessageService: SendMessageService;
+  let chatRoomMessageService: ChatRoomMessageService;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [ChatRoomMessageService, SendMessageService],
+    })
+      .overrideProvider(ChatRoomMessageService)
+      .useClass(class {})
+      .compile();
+
+    server = new Server();
+
+    chatRoomMessageService = module.get<ChatRoomMessageService>(
+      ChatRoomMessageService,
+    );
+
+    sendMessageSerSendMessageService =
+      module.get<SendMessageService>(SendMessageService);
+  });
+
+  it('チャットメッセージの保存とクライエントへの送信のユースケースが成功すること', async () => {
+    const senderParticipantId = 'chatRoomParticipantId0';
+    const roomId = 'chatRoomId0';
+    const senderUserId = 'userId0';
+    const message = 'test message';
+
+    const sender: ChatSenderInput = {
+      participant: {
+        id: senderParticipantId,
+        roomId,
+        userId: senderUserId,
+      },
+      user: {
+        id: senderUserId,
+        firebaseUID: 'firebaseUid0',
+        name: 'name0',
+        email: 'test0@test.com',
+        imageUrl: 'imageUrl0',
+        age: 11,
+        prefecture: 'prefecture0',
+        university: 'university0',
+        undergraduate: 'undergraduate0',
+        graduateYear: 'graduateYear0',
+        githubAccount: 'githubAccount0',
+        selfPublicity: 'selfPublicity0',
+        careerVision: 'name0',
+        programingSkills: ['HTML', 'CSS', 'JavaScript'],
+      },
+    };
+    const input: ChatMessageInput = {
+      message,
+      roomId,
+    };
+
+    chatRoomMessageService.create = jest.fn().mockResolvedValue({
+      content: message,
+      roomId,
+      senderId: senderParticipantId,
+    });
+
+    expect(sendMessageSerSendMessageService.handle(server, sender, input))
+      .resolves;
+
+    const resMessage = await sendMessageSerSendMessageService.handle(
+      server,
+      sender,
+      input,
+    );
+    expect(resMessage).toMatchObject({
+      content: input.message,
+      roomId: input.roomId,
+      senderId: sender.participant.id,
+      senderName: sender.user.name,
+      senderImage: sender.user.imageUrl,
+    });
+  });
+});

--- a/src/chat-event/use-case/send-message.service.ts
+++ b/src/chat-event/use-case/send-message.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@nestjs/common';
-import { ChatRoomMessageService } from 'src/chat-room-message/chat-room-message.service';
-import { ChatMessageInput } from '../dto/chat-message.input';
+import { ChatMessageInput } from 'src/chat-event/dto/chat-message.input';
 import { Server } from 'socket.io';
-import { ChatSenderInput } from '../dto/chat-sender.input';
+import { ChatSenderInput } from 'src/chat-event/dto/chat-sender.input';
+import { ChatRoomMessageService } from '../../chat-room-message/chat-room-message.service';
+import { ChatRoomMessageEntity } from 'src/chat-room-message/entities/chat-room-message.entity';
 
 @Injectable()
-export class SendMessage {
+export class SendMessageService {
   constructor(
     private readonly chatRoomMessageService: ChatRoomMessageService,
   ) {}
@@ -14,7 +15,7 @@ export class SendMessage {
     server: Server,
     sender: ChatSenderInput,
     input: ChatMessageInput,
-  ): Promise<void> {
+  ): Promise<ChatRoomMessageEntity> {
     const message = await this.chatRoomMessageService.create({
       content: input.message,
       roomId: input.roomId,
@@ -28,5 +29,7 @@ export class SendMessage {
     };
 
     server.emit('toClient', resMessage);
+
+    return resMessage;
   }
 }

--- a/src/chat-room-message/chat-room-message.service.ts
+++ b/src/chat-room-message/chat-room-message.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ChatRoomMessage, PrismaPromise } from '@prisma/client';
-import { PrismaService } from 'src/prisma.service';
+import { PrismaService } from '../prisma.service';
 import { CreateChatRoomMessageInput } from './dto/create-chat-room-message.input';
 
 @Injectable()

--- a/src/chat-room-message/use-case/find-many-message-with-sender-information.ts
+++ b/src/chat-room-message/use-case/find-many-message-with-sender-information.ts
@@ -16,23 +16,25 @@ export class FindManyMessagesWithSenderInformation {
     const messages = await this.chatRoomMessageService.findManyByRoomId(roomId);
 
     return await Promise.all(
-      messages.map(async (message: ChatRoomMessageEntity) => {
-        const senderParticipant = await this.chatRoomParticipantService.find(
-          message.senderId,
-        );
-        if (!senderParticipant) throw new Error('sender participant not found');
+      messages
+        .map(async (message: ChatRoomMessageEntity) => {
+          const senderParticipant = await this.chatRoomParticipantService.find(
+            message.senderId,
+          );
+          if (!senderParticipant) return;
 
-        const senderUser = await this.userService.find(
-          senderParticipant.userId,
-        );
-        if (!senderUser) throw new Error('sender user not found');
+          const senderUser = await this.userService.find(
+            senderParticipant.userId,
+          );
+          if (!senderUser) return;
 
-        return {
-          ...message,
-          senderImage: senderUser.imageUrl,
-          senderName: senderUser.name,
-        };
-      }),
+          return {
+            ...message,
+            senderImage: senderUser.imageUrl,
+            senderName: senderUser.name,
+          };
+        })
+        .filter(async (messageInfo) => !!(await messageInfo)),
     );
   }
 }

--- a/src/chat-room-participant/chat-room-participant.controller.ts
+++ b/src/chat-room-participant/chat-room-participant.controller.ts
@@ -1,22 +1,22 @@
 import { Controller, Get, Param, UseGuards } from '@nestjs/common';
 import { ChatRoomParticipantEntity } from './entities/chat-room-participant.entity';
 import { FirebaseAuth } from 'src/common/decorators/auth.decorator';
-import { FindChatRoomParticipantByRoomId } from './use-case/find-chat-room-participant-by-room-id';
+import { FindChatRoomParticipantByRoomIdAndUserId } from './use-case/find-chat-room-participant-by-room-id-and-user-id';
 import { AuthGuard } from 'src/common/guards/auth.guard';
 
 @Controller('chat-room-participant')
 export class ChatRoomParticipantController {
   constructor(
-    private readonly findChatRoomParticipantByRoomId: FindChatRoomParticipantByRoomId,
+    private readonly findChatRoomParticipantByRoomIdAndUserId: FindChatRoomParticipantByRoomIdAndUserId,
   ) {}
 
   @Get(':roomId')
   @UseGuards(AuthGuard)
-  async findByRoomId(
+  async findByRoomIdAndUserId(
     @FirebaseAuth() authUser: any,
     @Param('roomId') roomId: string,
   ): Promise<ChatRoomParticipantEntity> {
-    return await this.findChatRoomParticipantByRoomId.handle(
+    return await this.findChatRoomParticipantByRoomIdAndUserId.handle(
       authUser.uid,
       roomId,
     );

--- a/src/chat-room-participant/chat-room-participant.module.ts
+++ b/src/chat-room-participant/chat-room-participant.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { PrismaService } from 'src/prisma.service';
 import { ChatRoomParticipantService } from './chat-room-participant.service';
 import { ChatRoomParticipantController } from './chat-room-participant.controller';
-import { FindChatRoomParticipantByRoomId } from './use-case/find-chat-room-participant-by-room-id';
+import { FindChatRoomParticipantByRoomIdAndUserId } from './use-case/find-chat-room-participant-by-room-id-and-user-id';
 import { UserModule } from 'src/user/user.module';
 
 @Module({
@@ -10,7 +10,7 @@ import { UserModule } from 'src/user/user.module';
   providers: [
     ChatRoomParticipantService,
     PrismaService,
-    FindChatRoomParticipantByRoomId,
+    FindChatRoomParticipantByRoomIdAndUserId,
   ],
   controllers: [ChatRoomParticipantController],
   exports: [ChatRoomParticipantService],

--- a/src/chat-room-participant/use-case/find-chat-room-participant-by-room-id-and-user-id.ts
+++ b/src/chat-room-participant/use-case/find-chat-room-participant-by-room-id-and-user-id.ts
@@ -4,7 +4,7 @@ import { ChatRoomParticipantEntity } from '../entities/chat-room-participant.ent
 import { ChatRoomParticipantService } from '../chat-room-participant.service';
 
 @Injectable()
-export class FindChatRoomParticipantByRoomId {
+export class FindChatRoomParticipantByRoomIdAndUserId {
   constructor(
     private readonly userService: UserService,
     private readonly chatRoomParticipantService: ChatRoomParticipantService,

--- a/src/common/utils/delete-table.ts
+++ b/src/common/utils/delete-table.ts
@@ -8,7 +8,11 @@ export const deleteAllTable = async (prisma: PrismaClient): Promise<void> => {
   const deleteUserRecruitParticipants =
     prisma.userRecruitParticipant.deleteMany();
   const deleteCorporations = prisma.corporation.deleteMany();
-  const deleteEmployees = prisma.employee.deleteMany(); 
+  const deleteEmployees = prisma.employee.deleteMany();
+  const deleteChatRooms = prisma.chatRoom.deleteMany();
+  const deleteChatRoomParticipants = prisma.chatRoomParticipant.deleteMany();
+  const deleteChatRoomMessages = prisma.chatRoomMessage.deleteMany();
+
   await prisma.$transaction([
     deleteUserRecruitParticipants,
     deleteUserRecruitApplications,
@@ -16,5 +20,8 @@ export const deleteAllTable = async (prisma: PrismaClient): Promise<void> => {
     deleteUsers,
     deleteEmployees,
     deleteCorporations,
+    deleteChatRoomMessages,
+    deleteChatRoomParticipants,
+    deleteChatRooms,
   ]);
 };

--- a/test/e2e/chat-room-message.e2e-spec.ts
+++ b/test/e2e/chat-room-message.e2e-spec.ts
@@ -1,0 +1,113 @@
+import { INestApplication } from '@nestjs/common';
+import { PrismaService } from 'src/prisma.service';
+import { initTest, initTestApplication } from '../init';
+import * as request from 'supertest';
+import { createTestData, deleteAllTable } from '../fixture-handler';
+import { ChatRoomMessageEntity } from 'src/chat-room-message/entities/chat-room-message.entity';
+
+initTest();
+
+describe('ChatRoomMessage API', () => {
+  let prisma: PrismaService;
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    ({ app, prismaService: prisma } = await initTestApplication());
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await prisma.$disconnect();
+  });
+
+  afterEach(async () => {
+    await deleteAllTable(prisma);
+  });
+
+  const createThisTestData = async (): Promise<void> => {
+    const {
+      createUsers,
+      createUserRecruits,
+      createUserRecruitApplications,
+      createChatRooms,
+      createChatRoomParticipants,
+      createChatRoomMessages,
+    } = createTestData(prisma);
+    await createUsers();
+    await createUserRecruits();
+    await createUserRecruitApplications();
+    await createChatRooms();
+    await createChatRoomParticipants();
+    await createChatRoomMessages();
+  };
+
+  describe('GET /chat-room-message/:roomId', () => {
+    beforeEach(async () => {
+      await createThisTestData();
+    });
+
+    it('1つのチャットルーム内のメッセージ履歴を全権取得できる', async () => {
+      const roomId = 'chatRoomId0';
+      const operatorParticipantId = 'chatRoomParticipantId0';
+      const interlocutorParticipantId = 'chatRoomParticipantId1';
+      const messageContent = 'content';
+
+      await prisma.chatRoomParticipant.update({
+        where: { id: interlocutorParticipantId },
+        data: { roomId },
+      });
+
+      const allMessages = await prisma.chatRoomMessage.findMany();
+      for (const message of allMessages.slice(0, 5)) {
+        await prisma.chatRoomMessage.update({
+          where: { id: message.id },
+          data: { roomId, senderId: operatorParticipantId },
+        });
+      }
+      for (const message of allMessages.slice(5)) {
+        await prisma.chatRoomMessage.update({
+          where: { id: message.id },
+          data: { roomId, senderId: interlocutorParticipantId },
+        });
+      }
+
+      await request(app.getHttpServer())
+        .get(`/chat-room-message/${roomId}`)
+        .then(async (res) => {
+          console.log('port: ', app.getHttpServer());
+
+          expect(res.error).toBeFalsy();
+          expect(res.status).toBe(200);
+
+          const fetchedMessagesInfo = res.body;
+
+          expect(fetchedMessagesInfo).toHaveLength(10);
+
+          fetchedMessagesInfo
+            .slice(0, 5)
+            .forEach((messageInfo: ChatRoomMessageEntity, i: number) => {
+              expect(messageInfo).toMatchObject({
+                id: `chatRoomMessageId${i}`,
+                content: messageContent,
+                roomId,
+                senderId: operatorParticipantId,
+                senderImage: 'imageUrl0',
+                senderName: 'name0',
+              });
+            });
+          fetchedMessagesInfo
+            .slice(5)
+            .forEach((messageInfo: ChatRoomMessageEntity, i: number) => {
+              expect(messageInfo).toMatchObject({
+                id: `chatRoomMessageId${i + 5}`,
+                content: messageContent,
+                roomId,
+                senderId: interlocutorParticipantId,
+                senderImage: 'imageUrl1',
+                senderName: 'name1',
+              });
+            });
+        });
+    });
+  });
+});

--- a/test/e2e/chat-room-message.e2e-spec.ts
+++ b/test/e2e/chat-room-message.e2e-spec.ts
@@ -74,8 +74,6 @@ describe('ChatRoomMessage API', () => {
       await request(app.getHttpServer())
         .get(`/chat-room-message/${roomId}`)
         .then(async (res) => {
-          console.log('port: ', app.getHttpServer());
-
           expect(res.error).toBeFalsy();
           expect(res.status).toBe(200);
 

--- a/test/e2e/chat-room-participant.e2e-spec.ts
+++ b/test/e2e/chat-room-participant.e2e-spec.ts
@@ -1,0 +1,66 @@
+import { INestApplication } from '@nestjs/common';
+import { PrismaService } from 'src/prisma.service';
+import { initTest, initTestApplication } from '../init';
+import * as request from 'supertest';
+import { createTestData, deleteAllTable } from '../fixture-handler';
+
+initTest();
+
+describe('ChatRoomParticipant API', () => {
+  let prisma: PrismaService;
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    ({ app, prismaService: prisma } = await initTestApplication());
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await prisma.$disconnect();
+  });
+
+  afterEach(async () => {
+    await deleteAllTable(prisma);
+  });
+
+  const createThisTestData = async (): Promise<void> => {
+    const {
+      createUsers,
+      createUserRecruits,
+      createUserRecruitApplications,
+      createChatRooms,
+      createChatRoomParticipants,
+      createChatRoomMessages,
+    } = createTestData(prisma);
+    await createUsers();
+    await createUserRecruits();
+    await createUserRecruitApplications();
+    await createChatRooms();
+    await createChatRoomParticipants();
+    await createChatRoomMessages();
+  };
+
+  describe('GET /chat-room-participant/:roomId', () => {
+    beforeEach(async () => {
+      await createThisTestData();
+    });
+
+    it('操作ユーザーのユーザーIDと特定のチャットルームIDから一意のチャット参加者が取得できる', async () => {
+      const operatorUserId = 'userId0';
+      const roomId = 'chatRoomId0';
+
+      await request(app.getHttpServer())
+        .get(`/chat-room-participant/${roomId}`)
+        .then(async (res) => {
+          expect(res.error).toBeFalsy();
+          expect(res.status).toBe(200);
+
+          const fetchedParticipant = res.body;
+          expect(fetchedParticipant).toMatchObject({
+            roomId,
+            userId: operatorUserId,
+          });
+        });
+    });
+  });
+});

--- a/test/e2e/chat-room.e2e-spec.ts
+++ b/test/e2e/chat-room.e2e-spec.ts
@@ -1,0 +1,93 @@
+import { INestApplication } from '@nestjs/common';
+import { PrismaService } from 'src/prisma.service';
+import { initTest, initTestApplication } from '../init';
+import * as request from 'supertest';
+import { createTestData, deleteAllTable } from '../fixture-handler';
+import { ChatRoomWithInterlocutorAndMessageEntity } from 'src/chat-room/entities/chat-room-with-interlocutor-and-message-entity';
+
+initTest();
+
+describe('ChatRoom API', () => {
+  let prisma: PrismaService;
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    ({ app, prismaService: prisma } = await initTestApplication());
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await prisma.$disconnect();
+  });
+
+  afterEach(async () => {
+    await deleteAllTable(prisma);
+  });
+
+  const createThisTestData = async (): Promise<void> => {
+    const {
+      createUsers,
+      createUserRecruits,
+      createUserRecruitApplications,
+      createChatRooms,
+      createChatRoomParticipants,
+      createChatRoomMessages,
+    } = createTestData(prisma);
+    await createUsers();
+    await createUserRecruits();
+    await createUserRecruitApplications();
+    await createChatRooms();
+    await createChatRoomParticipants();
+    await createChatRoomMessages();
+  };
+
+  describe('GET /chat-room', () => {
+    beforeEach(async () => {
+      await createThisTestData();
+    });
+
+    it('操作ユーザーが関連するチャットルーム一覧を取得できる', async () => {
+      const operatorUserId = 'userId0';
+
+      const allParticipants = await prisma.chatRoomParticipant.findMany();
+      await Promise.all(
+        allParticipants.slice(0, 5).map(async (participant, i) => {
+          await prisma.chatRoomParticipant.update({
+            where: { id: participant.id },
+            data: { roomId: `chatRoomId${i}`, userId: operatorUserId },
+          });
+        }),
+      );
+      await Promise.all(
+        allParticipants.slice(5).map(async (participant, i) => {
+          await prisma.chatRoomParticipant.update({
+            where: { id: participant.id },
+            data: { roomId: `chatRoomId${i}` },
+          });
+        }),
+      );
+
+      await request(app.getHttpServer())
+        .get('/chat-room')
+        .then(async (res) => {
+          expect(res.error).toBeFalsy();
+          expect(res.status).toBe(200);
+
+          const fetchedRoomsInfo = res.body;
+
+          expect(fetchedRoomsInfo).toHaveLength(5);
+
+          fetchedRoomsInfo.forEach(
+            (roomInfo: ChatRoomWithInterlocutorAndMessageEntity, i: number) => {
+              expect(roomInfo).toMatchObject({
+                id: `chatRoomId${i}`,
+                interlocutorName: `name${i + 5}`,
+                interlocutorImageUrl: `imageUrl${i + 5}`,
+                latestMessage: 'content',
+              });
+            },
+          );
+        });
+    });
+  });
+});

--- a/test/e2e/user-recruit-application.e2e-spec.ts
+++ b/test/e2e/user-recruit-application.e2e-spec.ts
@@ -1,0 +1,100 @@
+import { INestApplication } from '@nestjs/common';
+import { PrismaService } from 'src/prisma.service';
+import { initTest, initTestApplication } from '../init';
+import * as request from 'supertest';
+import { createTestData, deleteAllTable } from '../fixture-handler';
+import { CreateUserRecruitApplicationInput } from 'src/user-recruit-application/dto/create-user-recruit-application.input';
+import { APPLY_FIRST_MESSAGE } from 'src/common/constants/message';
+
+initTest();
+
+describe('UserRecruitApplication API', () => {
+  let prisma: PrismaService;
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    ({ app, prismaService: prisma } = await initTestApplication());
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await prisma.$disconnect();
+  });
+
+  afterEach(async () => {
+    await deleteAllTable(prisma);
+  });
+
+  const createThisTestData = async (): Promise<void> => {
+    const { createUsers, createUserRecruits } = createTestData(prisma);
+    await createUsers();
+    await createUserRecruits();
+  };
+
+  describe('POST /user-recruit-application', () => {
+    beforeEach(async () => {
+      await createThisTestData();
+    });
+
+    it('応募に対するユーザーの「話を聞きたい」アクションが成功する', async () => {
+      const senderUserId = 'userId0';
+      const recipientUserId = 'userId1';
+      const recruitId = 'userRecruitId0';
+
+      await prisma.userRecruit.update({
+        where: { id: recruitId },
+        data: { recruiterId: recipientUserId },
+      });
+
+      const beforeChatRoomCounts = await prisma.chatRoom.count();
+      const beforeChatRoomParticipantCounts =
+        await prisma.chatRoomParticipant.count();
+
+      const input: CreateUserRecruitApplicationInput = {
+        recruitId,
+      };
+
+      await request(app.getHttpServer())
+        .post('/user-recruit-application')
+        .send(input)
+        .then(async (res) => {
+          expect(res.error).toBeFalsy();
+          expect(res.status).toBe(201);
+
+          const resData = res.body;
+          expect(resData).toMatchObject({
+            recruitId,
+          });
+
+          const afterChatRoomCounts = await prisma.chatRoom.count();
+          const afterChatRoomParticipantCounts =
+            await prisma.chatRoomParticipant.count();
+
+          //意図したチャットルームが1つ作成されていること
+          expect(afterChatRoomCounts).toBe(beforeChatRoomCounts + 1);
+          const createdRoom = await prisma.chatRoom.findUnique({
+            where: { id: resData.roomId },
+          });
+          expect(createdRoom).toBeDefined();
+
+          //「話を聞きたい」アクションをしたユーザーと募集主のユーザーがチャットの参加者になっていること
+          const createdParticipantsCounts =
+            await prisma.chatRoomParticipant.count({
+              where: { userId: { in: [senderUserId, recipientUserId] } },
+            });
+          expect(afterChatRoomParticipantCounts).toBe(
+            beforeChatRoomParticipantCounts + createdParticipantsCounts,
+          );
+
+          //最初のメッセージが「話を聞きたい」アクションをしたユーザーから正しく送られていること
+          const senderParticipant = await prisma.chatRoomParticipant.findFirst({
+            where: { userId: senderUserId },
+          });
+          const createdMessage = await prisma.chatRoomMessage.findFirst({
+            where: { roomId: createdRoom.id, senderId: senderParticipant.id },
+          });
+          expect(createdMessage.content).toBe(APPLY_FIRST_MESSAGE);
+        });
+    });
+  });
+});

--- a/test/fixture-handler.ts
+++ b/test/fixture-handler.ts
@@ -2,10 +2,15 @@ import { PrismaClient } from '@prisma/client';
 import { TestUsers } from './fixture/user';
 import { deleteAllTable as _deleteAllTable } from 'src/common/utils/delete-table';
 import { TestUserRecruits } from './fixture/user-recruit';
-import { TestUserRecruitApplications } from './fixture/user-recruit-applicant';
+import { TestUserRecruitApplications } from './fixture/user-recruit-application';
 import { TestUserRecruitParticipants } from './fixture/user-recruit-participant';
 import { TestEmployee } from './fixture/employee';
 import { TestCorporation } from './fixture/corporation';
+import { TestChatRooms } from './fixture/chat-room';
+import { TestChatRoomParticipants } from './fixture/chat-room-participant';
+import { TestChatRoomMessages } from './fixture/chat-room-message';
+import { INestApplication } from '@nestjs/common';
+import { io } from 'socket.io-client';
 
 export const createTestData = (prisma: PrismaClient) => {
   const createUsers = async (num = 10) => {
@@ -18,7 +23,7 @@ export const createTestData = (prisma: PrismaClient) => {
     });
   };
 
-  const createUserRecruitApplicants = async (num = 10) => {
+  const createUserRecruitApplications = async (num = 10) => {
     await prisma.userRecruitApplication.createMany({
       data: new TestUserRecruitApplications().create(num),
     });
@@ -32,26 +37,56 @@ export const createTestData = (prisma: PrismaClient) => {
 
   const createCorporations = async (num = 10) => {
     await prisma.corporation.createMany({
-      data: new TestCorporation().create(num)
-    })
-  }
+      data: new TestCorporation().create(num),
+    });
+  };
 
   const createEmployees = async (num = 10) => {
     await prisma.employee.createMany({
-      data: new TestEmployee().create(num)
-    })
-  } 
+      data: new TestEmployee().create(num),
+    });
+  };
+
+  const createChatRooms = async (num = 10) => {
+    await prisma.chatRoom.createMany({
+      data: new TestChatRooms().create(num),
+    });
+  };
+
+  const createChatRoomParticipants = async (num = 10) => {
+    await prisma.chatRoomParticipant.createMany({
+      data: new TestChatRoomParticipants().create(num),
+    });
+  };
+
+  const createChatRoomMessages = async (num = 10) => {
+    await prisma.chatRoomMessage.createMany({
+      data: new TestChatRoomMessages().create(num),
+    });
+  };
 
   return {
     createUsers,
     createUserRecruits,
-    createUserRecruitApplicants,
+    createUserRecruitApplications,
     createUserRecruitParticipants,
     createCorporations,
     createEmployees,
+    createChatRooms,
+    createChatRoomParticipants,
+    createChatRoomMessages,
   };
 };
 
 export const deleteAllTable = async (prisma: PrismaClient): Promise<void> => {
   await _deleteAllTable(prisma);
+};
+
+export const getWebsocketClient = (
+  app: INestApplication,
+  namespace?: string,
+) => {
+  return io(`http://localhost/8080`, {
+    autoConnect: true,
+  });
 };

--- a/test/fixture-handler.ts
+++ b/test/fixture-handler.ts
@@ -9,8 +9,6 @@ import { TestCorporation } from './fixture/corporation';
 import { TestChatRooms } from './fixture/chat-room';
 import { TestChatRoomParticipants } from './fixture/chat-room-participant';
 import { TestChatRoomMessages } from './fixture/chat-room-message';
-import { INestApplication } from '@nestjs/common';
-import { io } from 'socket.io-client';
 
 export const createTestData = (prisma: PrismaClient) => {
   const createUsers = async (num = 10) => {
@@ -80,13 +78,4 @@ export const createTestData = (prisma: PrismaClient) => {
 
 export const deleteAllTable = async (prisma: PrismaClient): Promise<void> => {
   await _deleteAllTable(prisma);
-};
-
-export const getWebsocketClient = (
-  app: INestApplication,
-  namespace?: string,
-) => {
-  return io(`http://localhost/8080`, {
-    autoConnect: true,
-  });
 };

--- a/test/fixture/chat-room-message.ts
+++ b/test/fixture/chat-room-message.ts
@@ -1,0 +1,18 @@
+import { ChatRoomMessage } from '@prisma/client';
+
+export class TestChatRoomMessages {
+  create(num = 10): ChatRoomMessage[] {
+    return [...new Array(num)].map((_, n) => {
+      const t = new Date();
+      t.setSeconds(t.getSeconds() - num + n);
+      return {
+        id: `chatRoomMessageId${n}`,
+        content: 'content',
+        roomId: `chatRoomId${n}`,
+        senderId: `chatRoomParticipantId${n}`,
+        createdAt: t,
+        updatedAt: t,
+      };
+    });
+  }
+}

--- a/test/fixture/chat-room-participant.ts
+++ b/test/fixture/chat-room-participant.ts
@@ -1,0 +1,15 @@
+import { ChatRoomParticipant } from '@prisma/client';
+
+export class TestChatRoomParticipants {
+  create(num = 10): ChatRoomParticipant[] {
+    return [...new Array(num)].map((_, n) => {
+      const t = new Date();
+      t.setSeconds(t.getSeconds() - num + n);
+      return {
+        id: `chatRoomParticipantId${n}`,
+        roomId: `chatRoomId${n}`,
+        userId: `userId${n}`,
+      };
+    });
+  }
+}

--- a/test/fixture/chat-room.ts
+++ b/test/fixture/chat-room.ts
@@ -1,0 +1,15 @@
+import { ChatRoom } from '@prisma/client';
+
+export class TestChatRooms {
+  create(num = 10): ChatRoom[] {
+    return [...new Array(num)].map((_, n) => {
+      const t = new Date();
+      t.setSeconds(t.getSeconds() - num + n);
+      return {
+        id: `chatRoomId${n}`,
+        createdAt: t,
+        updatedAt: t,
+      };
+    });
+  }
+}

--- a/test/fixture/user-recruit-application.ts
+++ b/test/fixture/user-recruit-application.ts
@@ -6,7 +6,7 @@ export class TestUserRecruitApplications {
       const t = new Date();
       t.setSeconds(t.getSeconds() - num + n);
       return {
-        id: `userRecruitApplicantId${n}`,
+        id: `userRecruitApplicationId${n}`,
         applicantId: `userId${n}`,
         recruitId: `userRecruitId${n}`,
       };


### PR DESCRIPTION
## 概要
チャット関連のテストコードを書きました。
メッセージ送信apiのe2eテストを書く上でWebSocketのGatewayにリクエストを送るテスト方法がわからなかったので、とりあえずメッセージ送信apiのユニットテストと、WebSocket通信部分以外のapiのe2eテスト分だけPRに乗せます🙇

## テスト結果
e2e
<img width="726" alt="image" src="https://github.com/ponsAoki/unite-api/assets/99397043/aca7857a-4181-44c6-ac93-1bbda5c293eb">

unit
<img width="726" alt="スクリーンショット 2023-07-24 16 36 18" src="https://github.com/ponsAoki/unite-api/assets/99397043/3e86564a-2a8d-4b32-b40d-92830a7fcf14">
